### PR TITLE
Fix for name conflicts due to generic class and id names

### DIFF
--- a/contactable.css
+++ b/contactable.css
@@ -1,4 +1,4 @@
-#contactable #contactable_inner {
+#contactable-inner {
 	background-image:url(images/contact.png);
 	color:#FFFFFF;
 	font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
@@ -20,7 +20,7 @@
 	z-index:100000;
 }
 
-#contactable #contactForm {
+#contactable-contactForm {
 	background-color:#333333;
 	border:2px solid #FFFFFF;
 	color:#FFFFFF;
@@ -38,7 +38,7 @@
 	z-index:99;
 }
 
-#contactable form#contactForm input, textarea, select {
+form#contactable-contactForm input, textarea, select {
 	background:#FFFFFF none repeat scroll 0 0;
 	outline-style:none;
 	outline-width:medium;
@@ -49,24 +49,24 @@
 	font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
 	margin-bottom:10px;
 }
-#contactable form#contactForm select {
+form#contactable-contactForm select {
 	width:335px;
 }
 
-#contactable form#contactForm p {
+form#contactable-contactForm p {
 	width:325px;
 	font-size:0.9em;
 }
 
-#contactable form#contactForm .disclaimer {
+form#contactable-contactForm .contactable-disclaimer {
 	*margin-left:20px;
 }
 
-#contactable #contactForm .green {
+#contactable-contactForm .contactable-green {
 	color:	#76b347;
 }
 
-#contactable #overlay {
+#contactable-overlay {
 	background-color:#666666;
 	display:none;
 	height:100%;
@@ -78,17 +78,17 @@
 	width:100%;
 	z-index:0;
 } 
-#contactable .invalid { background-color: #EDBE9C; }
-#contactable #name.invalid { background-color: #EDBE9C; } 
-#contactable #email.invalid { background-color: #EDBE9C; }
-#contactable #comment.invalid { background-color: #EDBE9C; }
+.contactable-invalid { background-color: #EDBE9C; }
+#contactable-name.contactable-invalid { background-color: #EDBE9C; } 
+#contactable-email.contactable-invalid { background-color: #EDBE9C; }
+#contactable-comment.contactable-invalid { background-color: #EDBE9C; }
 
-#contactable form#contactForm label{
+form#contactable-contactForm label{
 	*margin-left:20px;
 	line-height:150%;
 }
 
-#contactable form#contactForm #loading {
+form#contactable-contactForm #contactable-loading {
 	background: url(images/ajax-loader.gif) no-repeat;
 	width:66px;
 	height:66px;
@@ -96,7 +96,7 @@
 	display:none;
 }
 
-#contactable #callback {
+#contactable-callback {
 	font-size:1.1em;
 	color: #FFF;
 	width:325px;
@@ -104,14 +104,14 @@
 	display:none;
 }
 
-#contactable .holder {
+.contactable-holder {
 	margin:0 auto;
 	*margin-left:20px;
 	padding-top:20px;	
 }	
 
 /* Submit button */
-#contactable form#contactForm .submit {
+form#contactable-contactForm .contactable-submit {
   background-color: #7fbf4d;
   background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #7fbf4d), color-stop(100%, #63a62f));
   background-image: -webkit-linear-gradient(top, #7fbf4d, #63a62f);
@@ -135,7 +135,7 @@
   text-shadow: 0 -1px 0 #4c9021;
   width: 338px; }
 
-#contactable form#contactForm .submit:hover {
+form#contactable-contactForm .contactable-submit:hover {
     background-color: #76b347;
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #76b347), color-stop(100%, #5e9e2e));
     background-image: -webkit-linear-gradient(top, #76b347, #5e9e2e);
@@ -147,7 +147,8 @@
     -moz-box-shadow: inset 0 1px 0 0 #8dbf67;
     box-shadow: inset 0 1px 0 0 #8dbf67;
     cursor: pointer; }
-  button.cupid-green:active {
+
+button.contactable-cupid-green:active {
     border: 1px solid #5b992b;
     border-bottom: 1px solid #538c27;
     -webkit-box-shadow: inset 0 0 8px 4px #548c29, 0 1px 0 0 #eeeeee;

--- a/index.html
+++ b/index.html
@@ -6,16 +6,16 @@
 <body>
 
 <!--start contactable -->
-<div id="contactable"><!-- contactable html placeholder --></div>
+<div id="my-contact-div"><!-- contactable html placeholder --></div>
 
 <link rel="stylesheet" href="contactable.css" type="text/css" />
 
 <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
-<script type="text/javascript" src="jquery.contactable.min.js"></script>
+<script type="text/javascript" src="jquery.contactable.js"></script>
 
 <script>
 	jQuery(function(){
-		jQuery('#contactable').contactable(
+		jQuery('#my-contact-div').contactable(
         {
             subject: 'feedback URL:'+location.href,
             url: 'mail.php',

--- a/jquery.contactable.js
+++ b/jquery.contactable.js
@@ -34,15 +34,14 @@
 		return this.each(function() {
 
 			// Create the form and inject it into the DOM
-			var this_id_prefix = '#'+this.id+' '
-			,	dropdown = ''
+			var dropdown = ''
 			,	filter = /^([a-zA-Z0-9_\.\-])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+$/
 			,	dropdownLen = options.dropdownOptions.length
 			,	i;
 
 			// Add select option if applicable
 			if(options.dropdownTitle) {
-				dropdown += '<p><label for="dropdown">'+options.dropdownTitle+' </label><br /><select name="dropdown" id="dropdown" class="dropdown">';
+				dropdown += '<p><label for="contactable-dropdown">'+options.dropdownTitle+' </label><br /><select name="dropdown" id="contactable-dropdown" class="contactable-dropdown">';
 
 				for(i=0; i < dropdownLen; i++) {
 					dropdown += '<option value="'+options.dropdownOptions[i]+'">'+options.dropdownOptions[i]+'</option>';
@@ -52,71 +51,71 @@
 			}
 			// Form layout
 			/*	
-			*	<div id="contactable_inner"></div>
-			*	<form id="contactForm" method="" action="">
-			*  		<div id="loading"></div>
-			*		<div id="callback"></div>
-			* 		<div class="holder">
+			*	<div id="contactable-inner"></div>
+			*	<form id="contactable-contactForm" method="" action="">
+			*  		<div id="contactable-loading"></div>
+			*		<div id="contactable-callback"></div>
+			* 		<div class="contactable-holder">
 			* 			<p>
-			*				<label for="name">Name<span class="green"> * </span></label><br />
-			*				<input id="name" class="contact validate" name="name" />
+			*				<label for="contactable-name">Name<span class="contactable-green"> * </span></label><br />
+			*				<input id="contactable-name" class="contactable-contact contactable-validate" name="name" />
 			*			</p>
 			*			<p>
-			*				<label for="email"> Email address <span class="green"> * </span></label><br />
-			* 				<input id="email" class="contact validate" name="email" />
+			*				<label for="contactable-email"> Email address <span class="contactable-green"> * </span></label><br />
+			* 				<input id="contactable-email" class="contactable-contact contactable-validate" name="email" />
 			*			</p>
 			* 			<p>
-			*				<label for="message"> Message <span class="green"> * </span></label><br />
-			* 				<textarea id="message" name="message" class="message validate" rows="4" cols="30" ></textarea>
+			*				<label for="contactable-message"> Message <span class="contactable-green"> * </span></label><br />
+			* 				<textarea id="contactable-message" name="message" class="contactable-message contactable-validate" rows="4" cols="30" ></textarea>
 			*			</p>
 			*			<p>
-			*				<input class="submit" type="submit" value="Submit"/>
+			*				<input class="contactable-submit" type="submit" value="Submit"/>
 			*			</p>
-			*			<p class="disclaimer">Disclaimer</p>
+			*			<p class="contactable-disclaimer">Disclaimer</p>
 			*		</div>
 			*	</form>
 			*/
 
-			jQuery(this).html('<div id="contactable_inner"></div><form id="contactForm" method="" action=""><div id="loading"></div><div id="callback"></div><div class="holder"><p><label for="name">'+options.name+'<span class="green"> * </span></label><br /><input id="name" class="contact validate" name="name" /></p><p><label for="email">'+options.email+' <span class="green"> * </span></label><br /><input id="email" class="contact validate" name="email" /></p>'+dropdown+'<p><label for="message">'+options.message+' <span class="green"> * </span></label><br /><textarea id="message" name="message" class="message validate" rows="4" cols="30" ></textarea></p><p><input class="submit" type="submit" value="'+options.submit+'"/></p><p class="disclaimer">'+options.disclaimer+'</p></div></form>');
+			jQuery(this).html('<div id="contactable-inner"></div><form id="contactable-contactForm" method="" action=""><div id="contactable-loading"></div><div id="contactable-callback"></div><div class="contactable-holder"><p><label for="contactable-name">'+options.name+'<span class="contactable-green"> * </span></label><br /><input id="contactable-name" class="contactable-contact contactable-validate" name="name" /></p><p><label for="contactable-email">'+options.email+' <span class="contactable-green"> * </span></label><br /><input id="contactable-email" class="contactable-contact contactable-validate" name="email" /></p>'+dropdown+'<p><label for="contactable-message">'+options.message+' <span class="contactable-green"> * </span></label><br /><textarea id="contactable-message" name="message" class="contactable-message contactable-validate" rows="4" cols="30" ></textarea></p><p><input class="contactable-submit" type="submit" value="'+options.submit+'"/></p><p class="contactable-disclaimer">'+options.disclaimer+'</p></div></form>');
 			
 			// Toggle the form visibility
-			jQuery(this_id_prefix+'div#contactable_inner').toggle(function() {
-				jQuery(this_id_prefix+'#overlay').css({display: 'block'});
+			jQuery('#contactable-inner').toggle(function() {
+				jQuery('#contactable-overlay').css({display: 'block'});
 				jQuery(this).animate({"marginLeft": "-=5px"}, "2000"); 
-				jQuery(this_id_prefix+'#contactForm').animate({"marginLeft": "-=0px"}, "2000");
+				jQuery('#contactable-contactForm').animate({"marginLeft": "-=0px"}, "2000");
 				jQuery(this).animate({"marginLeft": "+=387px"}, "4000"); 
-				jQuery(this_id_prefix+'#contactForm').animate({"marginLeft": "+=390px"}, "4000"); 
+				jQuery('#contactable-contactForm').animate({"marginLeft": "+=390px"}, "4000"); 
 			}, 
 			function() {
-				jQuery(this_id_prefix+'#contactForm').animate({"marginLeft": "-=390px"}, "4000");
+				jQuery('#contactable-contactForm').animate({"marginLeft": "-=390px"}, "4000");
 				jQuery(this).animate({"marginLeft": "-=387px"}, "4000").animate({"marginLeft": "+=5px"}, "2000"); 
-				jQuery(this_id_prefix+'#overlay').css({display: 'none'});
+				jQuery('#contactable-overlay').css({display: 'none'});
 			});
 			
 			// Submit the form
-			jQuery(this_id_prefix+"#contactForm").submit(function() {
+			jQuery("#contactable-contactForm").submit(function() {
 				
 				// Validate the entries
 				var valid = true
 				,	params;
 
 				//Remove any previous errors
-				jQuery(this_id_prefix+"#contactForm .validate").each(function() {
-					jQuery(this).removeClass('invalid');
+				jQuery("#contactable-contactForm .contactable-validate").each(function() {
+					jQuery(this).removeClass('contactable-invalid');
 				});
 
 				// Loop through requigreen field
-				jQuery(this_id_prefix+"#contactForm .validate").each(function() {
+				jQuery("#contactable-contactForm .contactable-validate").each(function() {
 					
 					// Check the min length
 					if(jQuery(this).val().length < 2) {
-						jQuery(this).addClass("invalid");
+						jQuery(this).addClass("contactable-invalid");
 						valid = false;
 					}
 
 					//Check email is valid
-					if (!filter.test(jQuery(this_id_prefix+"#contactForm #email").val())) {
-						jQuery(this_id_prefix+"#contactForm #email").addClass("invalid");
+					if (!filter.test(jQuery("#contactable-contactForm #contactable-email").val())) {
+						jQuery("#contactable-contactForm #contactable-email").addClass("contactable-invalid");
 						valid = false;
 					}						
 				});
@@ -129,8 +128,8 @@
 
 			function submitForm() {
 				// Display loading animation
-				jQuery(this_id_prefix+'.holder').hide();
-				jQuery(this_id_prefix+'#loading').show();
+				jQuery('.contactable-holder').hide();
+				jQuery('#contactable-loading').show();
 				
 				// Trigger form submission if form is valid
 				jQuery.ajax({
@@ -138,35 +137,35 @@
 					url: options.url,
 					data: {
 						subject:options.subject, 
-						name:jQuery(this_id_prefix+'#name').val(), 
-						email:jQuery(this_id_prefix+'#email').val(), 
-						issue:jQuery(this_id_prefix+'#dropdown').val(), 
-						message:jQuery(this_id_prefix+'#message').val()
+						name:jQuery('#contactable-name').val(), 
+						email:jQuery('#contactable-email').val(), 
+						issue:jQuery('#contactable-dropdown').val(), 
+						message:jQuery('#contactable-message').val()
 					},
 					success: function(data) {
 						// Hide loading animation
-						jQuery(this_id_prefix+'#loading').css({display:'none'}); 
+						jQuery('#contactable-loading').css({display:'none'}); 
 
 						// Check for a valid server side response
 						if( data.response === 'success') {
-							jQuery(this_id_prefix+'#callback').show().append(options.recievedMsg);
+							jQuery('#contactable-callback').show().append(options.recievedMsg);
 							if(options.hideOnSubmit === true) {
 								//hide the tab after successful submition if requested
-								jQuery(this_id_prefix+'#contactForm').animate({dummy:1}, 2000).animate({"marginLeft": "-=450px"}, "slow");
-								jQuery(this_id_prefix+'div#contactable_inner').animate({dummy:1}, 2000).animate({"marginLeft": "-=447px"}, "slow").animate({"marginLeft": "+=5px"}, "fast"); 
-								jQuery(this_id_prefix+'#overlay').css({display: 'none'});	
+								jQuery('#contactable-contactForm').animate({dummy:1}, 2000).animate({"marginLeft": "-=450px"}, "slow");
+								jQuery('#contactable-inner').animate({dummy:1}, 2000).animate({"marginLeft": "-=447px"}, "slow").animate({"marginLeft": "+=5px"}, "fast"); 
+								jQuery('#contactable-overlay').css({display: 'none'});	
 							}
 						} else {
-							jQuery(this_id_prefix+'#callback').show().append(options.notRecievedMsg);
+							jQuery('#contactable-callback').show().append(options.notRecievedMsg);
 							setTimeout(function(){
-								jQuery(this_id_prefix+'.holder').show();
-								jQuery(this_id_prefix+'#callback').hide().html('');
+								jQuery('.contactable-holder').show();
+								jQuery('#contactable-callback').hide().html('');
 							},2000);
 						}
 					},
 					error:function(e){
-						jQuery(this_id_prefix+'#loading').css({display:'none'}); 
-						jQuery(this_id_prefix+'#callback').show().append(options.notRecievedMsg);
+						jQuery('#contactable-loading').css({display:'none'}); 
+						jQuery('#contactable-callback').show().append(options.notRecievedMsg);
 					}
 				});		
 			}

--- a/name.html
+++ b/name.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-GB" xml:lang="en-GB"> 
+<title>Contactable 1.5| jQuery Contact Plugin</title>
+<link rel="stylesheet" href="http://plugins.theodin.co.uk/jquery/contactable.1.5/contactable.css" type="text/css" />
+<link rel="stylesheet" href="demo.css" type="text/css" />
+<style>
+	/*label { display: inline-block; width: 150px; }*/
+	.dropdown, .fillin { margin-left: 100px; }
+</style>
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+<script type="text/javascript" src="http://plugins.theodin.co.uk/jquery/contactable.1.5/jquery.contactable.js"></script>
+</head>
+<body>
+
+<!--start contactable -->
+<div id="contactable"><!-- contactable html placeholder --></div>
+
+
+<script>
+	jQuery(function(){
+		jQuery('#contactable').contactable(
+        {
+            subject: 'feedback URL:'+location.href,
+            url: 'mail.php',
+            name: 'Name',
+            email: 'Email',
+            dropdownTitle: 'Issue',
+            dropdownOptions: ['General', 'Website bug', 'Feature request'],
+            message : 'Message',
+            submit : 'SEND',
+            recievedMsg : 'Thank you for your message',
+            notRecievedMsg : 'Sorry but your message could not be sent, try again later',
+            disclaimer: 'Please feel free to get in touch, we value your feedback',
+            hideOnSubmit: true
+        });
+	});
+	
+	$(function(){
+		$('#display').click(function() {
+			alert("Custom Flavor is: "+ $('#name').val());
+		});
+	});
+</script>
+<!--end contactable -->
+
+<div id="page">
+	<h2> &laquo; Click the contact link on the left</h2>
+	
+	<hr style="clear: both">
+	<h1>A Demonstation of Contactable Name-space Problems</h1>
+	<hr style="clear: both">
+	<p>
+	Note how Contactable's popup menu is incorrectly positioned, because this page
+	has conflicting CSS for the generic class-name 'dropdown'.
+	<p>
+	<label>Favorite Flavor:</label><select class="dropdown">
+		<option>Vanilla</option>
+		<option>Chocolate</option>
+		<option>Coffee</option>
+	</select>
+	<hr style="clear: both">
+	<p>
+	The display button should show the custom name in an alert, but it doesn't
+	because this page uses a conflicting HTML ID for the generic id 'name'.
+	<p>
+	<label>Custom Flavor Name:</label>
+		<input id="name" type="text" class="fillin" />
+		<button id="display">Display Flavor Name</button>
+	<p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This fix is a bit more involved. The issue is class and id names like 'email', which are generic enough that sometimes host pages will use the same names.

I've actually seen this problem in the "wild", where a bit of code like $('#email').val() was working fine until Contactable was added to the page template and causes the code to silently return the empty string (because it is getting the value of Contactable #email, not the host page's #email).

Contactable protects itself from duplicate ids by using the double-id selector kludge (e.g. $('#contactable #email').val()), but this leaves the host page vulnerable. Also, Contactable is vulnerable to style changes due to generic class names like 'dropdown'.

You can see demonstrations of id and class name problems in the name.html file in the commit.

HTML/CSS has no package/namespace system, so the next best solution is to create a pseudo-namespace by prefixing classes and ids with 'contactable-'. This isn't perfect, but for all practical purposes it reduces the chance of a name conflict to nil. It also simplifies the code a little, since there is no longer a need for double-id selectors.

A side benefit of this change is that the requirement of a div with id 'contactable' is removed -- the plugin can be applied to any div.

I'm happy to answer questions or adjust the patch as needed.

Cheers - Chuck
